### PR TITLE
Use generic TArgs on annotations

### DIFF
--- a/packages/core/src/custom-elements.json
+++ b/packages/core/src/custom-elements.json
@@ -1,5 +1,5 @@
 {
-  "timestamp": "2022-04-08T16:14:20",
+  "timestamp": "2022-06-17T15:42:57",
   "compiler": {
     "name": "@stencil/core",
     "version": "2.14.2",

--- a/packages/core/src/types/story.ts
+++ b/packages/core/src/types/story.ts
@@ -57,7 +57,7 @@ export type StoryUpdate<
   args: TArgs;
   argTypes: ArgTypes<TArgs>;
   parameters: Parameters;
-  initialArgs: Args;
+  initialArgs: TArgs;
 };
 
 /**
@@ -148,7 +148,7 @@ export type ComponentAnnotations<
    *
    * Decorators defined in Meta will be applied to every story variation.
    */
-  decorators?: Array<DecoratorFunction<TFramework, Args>>;
+  decorators?: Array<DecoratorFunction<TFramework, TArgs>>;
 
   /**
    * Dynamic data that are provided (and possibly updated by) Stories and its addons.
@@ -183,7 +183,7 @@ export type StoryAnnotations<
    *
    * Decorators defined in Meta will be applied to every story variation.
    */
-  decorators?: Array<DecoratorFunction<TFramework, Args>>;
+  decorators?: Array<DecoratorFunction<TFramework, TArgs>>;
 
 
   /**
@@ -253,10 +253,10 @@ export type StoryComponent<
   storyId: string;
   kinds: string[];
   storyName: string;
-  storyFn: StoryFn<TFramework, Args>;
+  storyFn: StoryFn<TFramework, TArgs>;
   component?: TFramework['component'];
   subcomponents?: Record<string, TFramework['component']>;
-  decorators?: Array<DecoratorFunction<TFramework, Args>>;
+  decorators?: Array<DecoratorFunction<TFramework, TArgs>>;
   args: Partial<TArgs>;
   argTypes: Partial<ArgTypes<TArgs>>;
   parameters?: Parameters;


### PR DESCRIPTION
## Issue

👋 I didn't see an issue template for simple bug fixes, so I went ahead and followed the contributing guidelines and fixed the issue I ran into.

There were a few typings that used `Args` instead of the parameterized `TArgs`.

## What I did

Changed `Args` to `TArgs` where appropriate.

## How to test

- [ ] ~Is this testable with Jest?~
- [ ] ~Does this need a new example in the demo apps?~
- [ ] ~Does this need an update to the documentation?~

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
